### PR TITLE
make ForwardDNS safe

### DIFF
--- a/goodbots.go
+++ b/goodbots.go
@@ -68,6 +68,10 @@ func ForwardDNS(host string) (string, error) {
 		},
 	}
 	ip, err := r.LookupIPAddr(context.Background(), host)
+	if err != nil {
+		return "", err
+	}
+
 	return ip[0].IP.String(), err
 }
 


### PR DESCRIPTION
The `ForwardDNS` func currently panics because `ip` can be empty.
Before this error was returned but this does not make sense as the `ip` value remains empty on failure.

This PR adds error handling before the return so this function will not panic.